### PR TITLE
Added function to extract input and output sizes needed 

### DIFF
--- a/src/scripts_A3/controller_spec.py
+++ b/src/scripts_A3/controller_spec.py
@@ -1,0 +1,49 @@
+# Standard library
+from typing import TYPE_CHECKING, Any, Sequence
+
+import mujoco as mj
+
+# Local libraries
+from ariel.body_phenotypes.robogen_lite.constructor import (
+    construct_mjspec_from_graph,
+)
+from ariel.simulation.environments import OlympicArena
+
+
+def find_in_out_size(
+    robot_graph : Any, 
+    SPAWN_POS : Sequence[float]
+    ) -> Sequence[int]:
+    """Finds out the input and output sizes, based on a robot specification
+
+    Args:
+        robot_graph (Any): The robot graph json file
+        SPAWN_POS (List[float...]): Must be the global variable for Spawning position
+                                    to ensure no undefined behaviors.
+
+    Returns:
+        int: Required input size for NN controller
+        int: Required output size for NN controller
+    """
+    core_test = construct_mjspec_from_graph(robot_graph)
+    
+    # Initialise controller to controller to None, always in the beginning.
+    mj.set_mjcb_control(None)  # DO NOT REMOVE
+
+    # Initialise world
+    # Import environments from ariel.simulation.environments
+    world_test = OlympicArena()
+
+    # Spawn robot in the world
+    # Check docstring for spawn conditions
+    world_test.spawn(core_test.spec, spawn_position=SPAWN_POS)
+
+    # Generate the model and data
+    model_test = world_test.spec.compile()
+    data_test = mj.MjData(model_test)
+    
+    # Extract input and output sizes
+    input_size = len(data_test.qpos)
+    output_size = model_test.nu
+    
+    return (input_size, output_size)

--- a/src/scripts_A3/creator_toolbox_prep.py
+++ b/src/scripts_A3/creator_toolbox_prep.py
@@ -44,13 +44,13 @@ def register_factories(
     Creates DEAP toolbox function to generate an allele, an individual, and a population. The distribution 
     to sample the value of each allele from can be specified. Alleles are assumed to be floats. 
     Args:
-        t : DEAP toolbox,
-        ind_type : The individual class/type, 
-        init_func : The function to sample alleles from
-        t_attr_name : The name for the sampling function to be set in toolbox
-        t_ind_name : The name for the individual generating function to be set in the toolbox
-        t_pop_name : The name for the population generating function to be set in the toolbox
-        k : The number of alleles per individual
+        t :             DEAP toolbox,
+        ind_type :      The individual class/type, 
+        init_func :     The function to sample alleles from
+        t_attr_name :   The name for the sampling function to be set in toolbox
+        t_ind_name :    The name for the individual generating function to be set in the toolbox
+        t_pop_name :    The name for the population generating function to be set in the toolbox
+        k :             The number of alleles per individual
     """
 
     if not hasattr(t, t_attr_name):


### PR DESCRIPTION
I've added a function to extract the needed input and output nodes for a NN controller from the body specification. It can be used as follows:
```python
# Import the function
from scripts_A3.controller_spec import find_in_out_size
 
# Some code ...

# After creating the robot specification from the body genotype
hpd = HighProbabilityDecoder(NUM_OF_MODULES)
robot_graph: DiGraph[Any] = hpd.probability_matrices_to_graph(
    p_matrices[0],
    p_matrices[1],
    p_matrices[2],
)
# ? ------------------------------------------------------------------ #
save_graph_as_json(
    robot_graph,
    DATA / "robot_graph.json",
)
# ? ------------------------------------------------------------------ #

# We can use the created specs to get the input and output sizes for the NN controller
input_size, output_size = find_in_out_size(robot_graph, SPAWN_POS)
```